### PR TITLE
Add binary exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,6 +66,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "binary",
+        "name": "Binary",
+        "uuid": "8d63f469-dadf-4809-80b6-604089be8cb4",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       }
     ]
   },

--- a/exercises/practice/binary/.docs/instructions.md
+++ b/exercises/practice/binary/.docs/instructions.md
@@ -1,0 +1,30 @@
+# Instructions
+
+Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
+
+Implement binary to decimal conversion.
+Given a binary input string, your program should produce a decimal output.
+The program should handle invalid inputs.
+
+## Note
+
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
+## About Binary (Base-2)
+
+Decimal is a base-10 system.
+
+A number 23 in base 10 notation can be understood as a linear combination of powers of 10:
+
+- The rightmost digit gets multiplied by 10^0 = 1
+- The next number gets multiplied by 10^1 = 10
+- ...
+- The *n*th number gets multiplied by 10^*(n-1)*.
+- All these values are summed.
+
+So: `23 => 2*10^1 + 3*10^0 => 2*10 + 3*1 = 23 base 10`
+
+Binary is similar, but uses powers of 2 rather than powers of 10.
+
+So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.

--- a/exercises/practice/binary/.meta/binary_example.odin
+++ b/exercises/practice/binary/.meta/binary_example.odin
@@ -1,0 +1,19 @@
+package binary
+
+// Returns the converted binary input string as an int.
+//
+// `ok` is false if the input string is not a valid binary number.
+convert :: proc(input: string) -> (val: int, ok: bool) {
+	for char in input {
+		switch char {
+		case '0':
+			val = val * 2
+		case '1':
+			val = val * 2 + 1
+		case:
+			return 0, false
+		}
+	}
+
+	return val, true
+}

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "pjlast"
+  ],
+  "files": {
+    "solution": [
+      "binary.odin"
+    ],
+    "test": [
+      "binary_test.odin"
+    ],
+    "example": [
+      ".meta/binary_example.odin"
+    ]
+  },
+  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.",
+  "source": "All of Computer Science",
+  "source_url": "https://www.wolframalpha.com/examples/mathematics/numbers/base-conversions"
+}

--- a/exercises/practice/binary/binary.odin
+++ b/exercises/practice/binary/binary.odin
@@ -1,0 +1,8 @@
+package binary
+
+// Returns the converted binary input string as an int.
+//
+// `ok` is false if the input string is not a valid binary number.
+convert :: proc(input: string) -> (val: int, ok: bool) {
+	#panic("Please implement the `convert` procedure.")
+}

--- a/exercises/practice/binary/binary_test.odin
+++ b/exercises/practice/binary/binary_test.odin
@@ -1,0 +1,102 @@
+/* These are the unit tests for the exercise. Only the first one is enabled to start with. You can
+ * enable the other tests by uncommenting the `@(test)` attribute of the test procedure. Your
+ * solution should pass all tests before it is ready for submission.
+ */
+
+package binary
+
+import "core:testing"
+
+check_convert_values :: proc(
+	t: ^testing.T,
+	input: string,
+	want_output: int,
+	want_ok: bool,
+) {
+	v, ok := convert(input)
+	testing.expect_value(t, want_output, v)
+	testing.expect_value(t, want_ok, ok)
+}
+
+@(test)
+test_binary_0_is_decimal_0 :: proc(t: ^testing.T) {
+	check_convert_values(t, "0", 0, true)
+}
+
+// @(test)
+test_binary_1_is_decimal_1 :: proc(t: ^testing.T) {
+	check_convert_values(t, "1", 1, true)
+}
+
+// @(test)
+test_binary_10_is_decimal_2 :: proc(t: ^testing.T) {
+	check_convert_values(t, "10", 2, true)
+}
+
+// @(test)
+test_binary_11_is_decimal_3 :: proc(t: ^testing.T) {
+	check_convert_values(t, "11", 3, true)
+}
+
+// @(test)
+test_binary_100_is_decimal_4 :: proc(t: ^testing.T) {
+	check_convert_values(t, "100", 4, true)
+}
+
+// @(test)
+test_binary_1001_is_decimal_9 :: proc(t: ^testing.T) {
+	check_convert_values(t, "1001", 9, true)
+}
+
+// @(test)
+test_binary_11010_is_decimal_26 :: proc(t: ^testing.T) {
+	check_convert_values(t, "11010", 26, true)
+}
+
+// @(test)
+test_binary_10001101000_is_decimal_1128 :: proc(t: ^testing.T) {
+	check_convert_values(t, "10001101000", 1128, true)
+}
+
+// @(test)
+test_binary_ignores_leading_zeros :: proc(t: ^testing.T) {
+	check_convert_values(t, "000011111", 31, true)
+}
+
+// @(test)
+test_2_is_not_a_valid_binary_digit :: proc(t: ^testing.T) {
+	check_convert_values(t, "2", 0, false)
+}
+
+// @(test)
+test_a_number_containing_a_non_binary_digit_is_invalid :: proc(t: ^testing.T) {
+	check_convert_values(t, "01201", 0, false)
+}
+
+// @(test)
+test_a_number_with_trailing_non_binary_characters_is_invalid :: proc(
+	t: ^testing.T,
+) {
+	check_convert_values(t, "10nope", 0, false)
+}
+
+// @(test)
+test_a_number_with_leading_non_binary_characters_is_invalid :: proc(
+	t: ^testing.T,
+) {
+	check_convert_values(t, "nope10", 0, false)
+}
+
+// @(test)
+test_a_number_with_internal_non_binary_characters_is_invalid :: proc(
+	t: ^testing.T,
+) {
+	check_convert_values(t, "10nope10", 0, false)
+}
+
+// @(test)
+test_a_number_and_a_word_whitespace_separated_is_invalid :: proc(
+	t: ^testing.T,
+) {
+	check_convert_values(t, "001 nope", 0, false)
+}


### PR DESCRIPTION
Implements the `binary` exercise from https://github.com/exercism/odin/issues/26

The example solution could be implemented with either a switch-case or an if-else. I'm not sure if one would be preferred over the other for this exercise.

The function also returns an `(int, bool)` pair. Thought a simple `ok` variable would be easiest here.