### PR TITLE
Update Odin-setup and Odin compiler versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,11 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 
       - name: Setup Odin
-        uses: laytan/setup-odin@3df60bd622575fda7efa4a3ec928f446bcae1a0a
+        uses: laytan/setup-odin@1e0d12e3bffd1aa07e586a3d9effb2d991a19d36
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           llvm-version: 18
-          release: dev-2024-09
+          release: dev-2025-10
 
       - name: Verify all exercises
         run: bin/verify-exercises


### PR DESCRIPTION
Update the github workflow test.yml with a newer version of laytan/setup-odin (using the latest available) and of the odin compiler (using dev-2025-10). There is a newer version of Odin (dev-2025-11) but it just came out. I have been confirm that all the Exercism/Odin track exercises in the main branch and the PRs run with dev-2025-10 on my local machine. 