### PR TITLE
Apply the "compile cleanly" flags.

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -61,9 +61,12 @@ run_test() {
     cp "${files[test]}" "${tmp_path}/${snake_name}_test.odin"
 
     # Run the tests using the example file to verify that it is a valid solution.
+    # Turn off `-e`, we don't want to abort if there's a non-zero status.
     local result status
-    result=$( odin test "${tmp_path}" 2>&1 )
+    set +e
+    result=$( odin test "${tmp_path}" -vet -strict-style -vet-tabs -disallow-do -warnings-as-errors 2>&1 )
     status=$?
+    set -e
 
     echo "$result"
 
@@ -84,6 +87,7 @@ run_test() {
     # but only fail on the most complicated one. Since the purpose of this test is mostly to
     # double-check that the example didn't accidentally get duplicated as the stub, this isn't
     # too critical for now.
+    # Note that we don't pass all the compile flags: we know it won't satisfy them.
     # glennj notes: this invocation seems to leave a tmp file behind
     if odin test "${tmp_path}" 2>/dev/null ; then
         echo >&2 'ERROR: The stub file must not pass the tests!'

--- a/exercises/practice/circular-buffer/circular_buffer_test.odin
+++ b/exercises/practice/circular-buffer/circular_buffer_test.odin
@@ -8,7 +8,7 @@ test_reading_empty_buffer_should_fail :: proc(t: ^testing.T) {
 	buffer := new_buffer(1)
 	defer destroy_buffer(&buffer)
 
-	rd_value, rd_error := read(&buffer)
+	_, rd_error := read(&buffer)
 	testing.expect_value(t, rd_error, Error.BufferEmpty)
 }
 
@@ -139,7 +139,7 @@ test_items_cleared_out_of_buffer_cant_be_read :: proc(t: ^testing.T) {
 
 	clear(&buffer)
 
-	rd_value, rd_error := read(&buffer)
+	_, rd_error := read(&buffer)
 	testing.expect_value(t, rd_error, Error.BufferEmpty)
 }
 

--- a/exercises/practice/grains/.meta/example.odin
+++ b/exercises/practice/grains/.meta/example.odin
@@ -23,7 +23,9 @@ count :: proc(n: int) -> (u64, u64) {
 
 // Returns the number of grains on the specified square.
 square :: proc(n: int) -> (u64, Error) {
-	if n < 1 || n > 64 do return 0, .InvalidSquare
+	if n < 1 || n > 64 {
+		return 0, .InvalidSquare
+	}
 	c, _ := count(n)
 	return c, .None
 }


### PR DESCRIPTION
Also:
- Fix bug where test errors/failures would abort prematurely. 
- Apply vet fixes to circular-buffer and grains.

Completes half of #60