### PR TITLE
Implement the Bowling Exercise for the Odin Track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/ols.exe
 *.bin
 tmp.*
 .vscode/
+**/out/

--- a/config.json
+++ b/config.json
@@ -122,6 +122,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2
+      },
+      {
+        "slug": "bowling",
+        "name": "Bowling",
+        "uuid": "85bedaa1-0898-4698-bf14-0a67ef9b7668",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 9
       }
     ]
   },

--- a/exercises/practice/bowling/.docs/instructions.md
+++ b/exercises/practice/bowling/.docs/instructions.md
@@ -1,0 +1,56 @@
+# Instructions
+
+Score a bowling game.
+
+Bowling is a game where players roll a heavy ball to knock down pins arranged in a triangle.
+Write code to keep track of the score of a game of bowling.
+
+## Scoring Bowling
+
+The game consists of 10 frames.
+A frame is composed of one or two ball throws with 10 pins standing at frame initialization.
+There are three cases for the tabulation of a frame.
+
+- An open frame is where a score of less than 10 is recorded for the frame.
+  In this case the score for the frame is the number of pins knocked down.
+
+- A spare is where all ten pins are knocked down by the second throw.
+  The total value of a spare is 10 plus the number of pins knocked down in their next throw.
+
+- A strike is where all ten pins are knocked down by the first throw.
+  The total value of a strike is 10 plus the number of pins knocked down in the next two throws.
+  If a strike is immediately followed by a second strike, then the value of the first strike cannot be determined until the ball is thrown one more time.
+
+Here is a three frame example:
+
+|  Frame 1   |  Frame 2   |     Frame 3      |
+| :--------: | :--------: | :--------------: |
+| X (strike) | 5/ (spare) | 9 0 (open frame) |
+
+Frame 1 is (10 + 5 + 5) = 20
+
+Frame 2 is (5 + 5 + 9) = 19
+
+Frame 3 is (9 + 0) = 9
+
+This means the current running total is 48.
+
+The tenth frame in the game is a special case.
+If someone throws a spare or a strike then they get one or two fill balls respectively.
+Fill balls exist to calculate the total of the 10th frame.
+Scoring a strike or spare on the fill ball does not give the player more fill balls.
+The total value of the 10th frame is the total number of pins knocked down.
+
+For a tenth frame of X1/ (strike and a spare), the total value is 20.
+
+For a tenth frame of XXX (three strikes), the total value is 30.
+
+## Requirements
+
+Write code to keep track of the score of a game of bowling.
+It should support two operations:
+
+- `roll(pins : int)` is called each time the player rolls a ball.
+  The argument is the number of pins knocked down.
+- `score() : int` is called only at the very end of the game.
+  It returns the total score for that game.

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "rmonnet"
+  ],
+  "files": {
+    "solution": [
+      "bowling.odin"
+    ],
+    "test": [
+      "bowling_test.odin"
+    ],
+    "example": [
+      ".meta/example.odin"
+    ]
+  },
+  "blurb": "Score a bowling game.",
+  "source": "The Bowling Game Kata from UncleBob",
+  "source_url": "https://web.archive.org/web/20221001111000/http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
+}

--- a/exercises/practice/bowling/.meta/example.odin
+++ b/exercises/practice/bowling/.meta/example.odin
@@ -1,0 +1,93 @@
+package bowling
+
+MAX_PINS :: 10
+LAST_FRAME :: 9 // First Frame starts at 0 (not 1).
+EXTRA_FRAME :: 10
+
+Game :: struct {
+	points:    [11][2]int,
+	cur_frame: int,
+	cur_ball:  int,
+}
+
+Error :: enum {
+	None,
+	Game_Over,
+	Game_Not_Over,
+	Roll_Not_Between_1_And_10,
+	Rolls_in_Frame_Exceed_10_Points,
+}
+
+new_game :: proc() -> Game {
+	return Game{}
+}
+
+is_strike :: proc(g: Game, frame: int) -> bool {
+
+	return g.points[frame][0] == MAX_PINS
+}
+
+is_spare :: proc(g: Game, frame: int) -> bool {
+
+	return g.points[frame][0] != MAX_PINS && (g.points[frame][0] + g.points[frame][1]) == MAX_PINS
+}
+
+is_game_over :: proc(g: Game) -> bool {
+
+	return(
+		g.cur_frame > EXTRA_FRAME ||
+		g.cur_frame == EXTRA_FRAME &&
+			!is_strike(g, LAST_FRAME) &&
+			!((is_spare(g, LAST_FRAME) && g.cur_ball == 0)) \
+	)
+}
+
+roll :: proc(g: ^Game, pins: int) -> Error {
+
+	if is_game_over(g^) {
+		return .Game_Over
+	}
+	if pins < 0 || pins > MAX_PINS {
+		return .Roll_Not_Between_1_And_10
+	}
+	if g.cur_ball == 1 &&
+	   (g.points[g.cur_frame][0] + pins) > MAX_PINS &&
+	   !(g.cur_frame == EXTRA_FRAME && is_strike(g^, EXTRA_FRAME)) {
+		return .Rolls_in_Frame_Exceed_10_Points
+	}
+	g.points[g.cur_frame][g.cur_ball] = pins
+	if g.cur_frame < EXTRA_FRAME && is_strike(g^, g.cur_frame) {
+		g.cur_frame += 1
+	} else {
+		g.cur_ball += 1
+		if g.cur_ball == 2 {
+			g.cur_frame += 1
+			g.cur_ball = 0
+		}
+	}
+	return .None
+}
+
+score :: proc(g: Game) -> (int, Error) {
+
+	if !is_game_over(g) {
+		return 0, .Game_Not_Over
+	}
+	score := 0
+	for frame := 0; frame < EXTRA_FRAME; frame += 1 {
+
+		score += g.points[frame][0] + g.points[frame][1]
+		if is_spare(g, frame) {
+			score += g.points[frame + 1][0]
+		}
+		if is_strike(g, frame) {
+			score += g.points[frame + 1][0]
+			if frame == LAST_FRAME || !is_strike(g, frame + 1) {
+				score += g.points[frame + 1][1]
+			} else {
+				score += g.points[frame + 2][0]
+			}
+		}
+	}
+	return score, .None
+}

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -1,0 +1,103 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[656ae006-25c2-438c-a549-f338e7ec7441]
+description = "should be able to score a game with all zeros"
+
+[f85dcc56-cd6b-4875-81b3-e50921e3597b]
+description = "should be able to score a game with no strikes or spares"
+
+[d1f56305-3ac2-4fe0-8645-0b37e3073e20]
+description = "a spare followed by zeros is worth ten points"
+
+[0b8c8bb7-764a-4287-801a-f9e9012f8be4]
+description = "points scored in the roll after a spare are counted twice"
+
+[4d54d502-1565-4691-84cd-f29a09c65bea]
+description = "consecutive spares each get a one roll bonus"
+
+[e5c9cf3d-abbe-4b74-ad48-34051b2b08c0]
+description = "a spare in the last frame gets a one roll bonus that is counted once"
+
+[75269642-2b34-4b72-95a4-9be28ab16902]
+description = "a strike earns ten points in a frame with a single roll"
+
+[037f978c-5d01-4e49-bdeb-9e20a2e6f9a6]
+description = "points scored in the two rolls after a strike are counted twice as a bonus"
+
+[1635e82b-14ec-4cd1-bce4-4ea14bd13a49]
+description = "consecutive strikes each get the two roll bonus"
+
+[e483e8b6-cb4b-4959-b310-e3982030d766]
+description = "a strike in the last frame gets a two roll bonus that is counted once"
+
+[9d5c87db-84bc-4e01-8e95-53350c8af1f8]
+description = "rolling a spare with the two roll bonus does not get a bonus roll"
+
+[576faac1-7cff-4029-ad72-c16bcada79b5]
+description = "strikes with the two roll bonus do not get bonus rolls"
+
+[efb426ec-7e15-42e6-9b96-b4fca3ec2359]
+description = "last two strikes followed by only last bonus with non strike points"
+
+[72e24404-b6c6-46af-b188-875514c0377b]
+description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"
+
+[62ee4c72-8ee8-4250-b794-234f1fec17b1]
+description = "all strikes is a perfect game"
+
+[1245216b-19c6-422c-b34b-6e4012d7459f]
+description = "rolls cannot score negative points"
+
+[5fcbd206-782c-4faa-8f3a-be5c538ba841]
+description = "a roll cannot score more than 10 points"
+
+[fb023c31-d842-422d-ad7e-79ce1db23c21]
+description = "two rolls in a frame cannot score more than 10 points"
+
+[6082d689-d677-4214-80d7-99940189381b]
+description = "bonus roll after a strike in the last frame cannot score more than 10 points"
+
+[e9565fe6-510a-4675-ba6b-733a56767a45]
+description = "two bonus rolls after a strike in the last frame cannot score more than 10 points"
+
+[2f6acf99-448e-4282-8103-0b9c7df99c3d]
+description = "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike"
+
+[6380495a-8bc4-4cdb-a59f-5f0212dbed01]
+description = "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike"
+
+[2b2976ea-446c-47a3-9817-42777f09fe7e]
+description = "second bonus roll after a strike in the last frame cannot score more than 10 points"
+
+[29220245-ac8d-463d-bc19-98a94cfada8a]
+description = "an unstarted game cannot be scored"
+
+[4473dc5d-1f86-486f-bf79-426a52ddc955]
+description = "an incomplete game cannot be scored"
+
+[2ccb8980-1b37-4988-b7d1-e5701c317df3]
+description = "cannot roll if game already has ten frames"
+
+[4864f09b-9df3-4b65-9924-c595ed236f1b]
+description = "bonus rolls for a strike in the last frame must be rolled before score can be calculated"
+
+[537f4e37-4b51-4d1c-97e2-986eb37b2ac1]
+description = "both bonus rolls for a strike in the last frame must be rolled before score can be calculated"
+
+[8134e8c1-4201-4197-bf9f-1431afcde4b9]
+description = "bonus roll for a spare in the last frame must be rolled before score can be calculated"
+
+[9d4a9a55-134a-4bad-bae8-3babf84bd570]
+description = "cannot roll after bonus roll for spare"
+
+[d3e02652-a799-4ae3-b53b-68582cc604be]
+description = "cannot roll after bonus rolls for strike"

--- a/exercises/practice/bowling/bowling.odin
+++ b/exercises/practice/bowling/bowling.odin
@@ -1,0 +1,20 @@
+package bowling
+
+// Populate the Game data structure as needed.
+Game :: struct {}
+
+Error :: enum {
+	None,
+	Game_Over,
+	Game_Not_Over,
+	Roll_Not_Between_1_And_10,
+	Rolls_in_Frame_Exceed_10_Points,
+}
+
+roll :: proc(g: ^Game, pins: int) -> Error {
+	#panic("Implement the `roll` procedure.")
+}
+
+score :: proc(g: Game) -> (int, Error) {
+	#panic("Implement the `score` procedure.")
+}

--- a/exercises/practice/bowling/bowling_test.odin
+++ b/exercises/practice/bowling/bowling_test.odin
@@ -1,0 +1,409 @@
+package bowling
+
+import "core:fmt"
+import "core:testing"
+
+apply_previous_rolls :: proc(t: ^testing.T, g: ^Game, rolls: []int, loc := #caller_location) {
+
+	for pins, index in rolls {
+		if err := roll(g, pins); err != .None {
+			err_msg := fmt.aprintf(
+				"Unexpected error while applying previous roll #%d of %d pins: %v",
+				index,
+				pins,
+				err,
+			)
+			testing.fail_now(t, err_msg, loc = loc)
+		}
+	}
+}
+
+@(test)
+test_should_be_able_to_score_a_game_with_all_zeros :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 0
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_should_be_able_to_score_a_game_with_no_strikes_or_spares :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 90
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_a_spare_followed_by_zeros_is_worth_ten_points :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 10
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_points_scored_in_the_roll_after_a_spare_are_counted_twice :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 16
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_consecutive_spares_each_get_a_one_roll_bonus :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 31
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_a_spare_in_the_last_frame_gets_a_one_roll_bonus_that_is_counted_once :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 17
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_a_strike_earns_ten_points_in_a_frame_with_a_single_roll :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 10
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_points_scored_in_the_two_rolls_after_a_strike_are_counted_twice_as_a_bonus :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 26
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_consecutive_strikes_each_get_the_two_roll_bonus :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 81
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_a_strike_in_the_last_frame_gets_a_two_roll_bonus_that_is_counted_once :: proc(t: ^testing.T) {
+
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 18
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_rolling_a_spare_with_the_two_roll_bonus_does_not_get_a_bonus_roll :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 20
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_strikes_with_the_two_roll_bonus_do_not_get_bonus_rolls :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 30
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_last_two_strikes_followed_by_only_last_bonus_with_non_strike_points :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 0, 1}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 31
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_a_strike_with_the_one_roll_bonus_after_a_spare_in_the_last_frame_does_not_get_a_bonus :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 20
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_all_strikes_is_a_perfect_game :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 300
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_rolls_cannot_score_negative_points :: proc(t: ^testing.T) {
+
+	game := new_game()
+	error := roll(&game, -1)
+
+	testing.expect_value(t, error, Error.Roll_Not_Between_1_And_10)
+}
+
+@(test)
+test_a_roll_cannot_score_more_than_10_points :: proc(t: ^testing.T) {
+
+
+	game := new_game()
+	error := roll(&game, 11)
+
+	testing.expect_value(t, error, Error.Roll_Not_Between_1_And_10)
+}
+
+@(test)
+test_two_rolls_in_a_frame_cannot_score_more_than_10_points :: proc(t: ^testing.T) {
+
+	game := new_game()
+	error := roll(&game, 5)
+	testing.expect_value(t, error, Error.None)
+	error = roll(&game, 6)
+
+	testing.expect_value(t, error, Error.Rolls_in_Frame_Exceed_10_Points)
+}
+
+@(test)
+test_bonus_roll_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10}
+	apply_previous_rolls(t, &game, rolls[:])
+	error := roll(&game, 11)
+
+	testing.expect_value(t, error, Error.Roll_Not_Between_1_And_10)
+}
+
+@(test)
+test_two_bonus_rolls_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5}
+	apply_previous_rolls(t, &game, rolls[:])
+	error := roll(&game, 6)
+
+	testing.expect_value(t, error, Error.Rolls_in_Frame_Exceed_10_Points)
+}
+
+@(test)
+test_two_bonus_rolls_after_a_strike_in_the_last_frame_can_score_more_than_10_points_if_one_is_a_strike :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6}
+	apply_previous_rolls(t, &game, rolls[:])
+	result, error := score(game)
+	expected := 26
+
+	testing.expect_value(t, error, Error.None)
+	testing.expect_value(t, result, expected)
+}
+
+@(test)
+test_the_second_bonus_rolls_after_a_strike_in_the_last_frame_cannot_be_a_strike_if_the_first_one_is_not_a_strike :: proc(
+	t: ^testing.T,
+) {
+
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6}
+	apply_previous_rolls(t, &game, rolls[:])
+	error := roll(&game, 10)
+
+	testing.expect_value(t, error, Error.Rolls_in_Frame_Exceed_10_Points)
+}
+
+@(test)
+test_second_bonus_roll_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10}
+	apply_previous_rolls(t, &game, rolls[:])
+	error := roll(&game, 11)
+
+	testing.expect_value(t, error, Error.Roll_Not_Between_1_And_10)
+}
+
+@(test)
+test_an_unstarted_game_cannot_be_scored :: proc(t: ^testing.T) {
+
+	game := new_game()
+	_, error := score(game)
+
+	testing.expect_value(t, error, Error.Game_Not_Over)
+}
+
+@(test)
+test_an_incomplete_game_cannot_be_scored :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	_, error := score(game)
+
+	testing.expect_value(t, error, Error.Game_Not_Over)
+}
+
+@(test)
+test_cannot_roll_if_game_already_has_ten_frames :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	apply_previous_rolls(t, &game, rolls[:])
+	error := roll(&game, 0)
+
+	testing.expect_value(t, error, Error.Game_Over)
+}
+
+@(test)
+test_bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10}
+	apply_previous_rolls(t, &game, rolls[:])
+	_, error := score(game)
+
+	testing.expect_value(t, error, Error.Game_Not_Over)
+}
+
+@(test)
+test_both_bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10}
+	apply_previous_rolls(t, &game, rolls[:])
+	_, error := score(game)
+
+	testing.expect_value(t, error, Error.Game_Not_Over)
+}
+
+@(test)
+test_bonus_roll_for_a_spare_in_the_last_frame_must_be_rolled_before_score_can_be_calculated :: proc(
+	t: ^testing.T,
+) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3}
+	apply_previous_rolls(t, &game, rolls[:])
+	_, error := score(game)
+
+	testing.expect_value(t, error, Error.Game_Not_Over)
+}
+
+@(test)
+test_cannot_roll_after_bonus_roll_for_spare :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 2}
+	apply_previous_rolls(t, &game, rolls[:])
+	error := roll(&game, 2)
+
+	testing.expect_value(t, error, Error.Game_Over)
+}
+
+@(test)
+test_cannot_roll_after_bonus_rolls_for_strike :: proc(t: ^testing.T) {
+
+	game := new_game()
+	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 3, 2}
+	apply_previous_rolls(t, &game, rolls[:])
+	error := roll(&game, 2)
+
+	testing.expect_value(t, error, Error.Game_Over)
+}


### PR DESCRIPTION
Gave it a difficulty of 9 (hard) because of all the tedious logic when hitting a strike or a spare on the last frame.

Added the `out/` directory to `.gitignore`, this is generated by the Odin debugger.