### PR TITLE
Add a check-exercise.sh script to run before submitting a PR and updated formatting per latest odinfmt config

### DIFF
--- a/bin/check-exercise.sh
+++ b/bin/check-exercise.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+
+if [ $# -ne 1 ]; then
+    echo "Usage: bin/check-exercise.sh <path to exercise>"
+    exit 1
+fi
+
+expected_number_of_tests () {
+    num_tests=$(grep -c "description = " "${exercise_path}/.meta/tests.toml")
+    ignored_tests=$(grep -c "include = false" "${exercise_path}/.meta/tests.toml")
+    echo $(( num_tests - ignored_tests ))
+}
+
+actual_number_of_tests () {
+    grep -c "@(test)" "${exercise_path}/${exercise_name}_test.odin"
+}
+
+create_temp_dir() {
+    TEMP_DIR=$(mktemp -d -t check-exercise-XXXXXXXX)
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to create temporary directory." >&2
+        exit 1
+    fi
+}
+
+cleanup_temp_dir() {
+    if [ -d "$TEMP_DIR" ]; then
+        # -r: recursively delete contents; -f: force deletion (no prompts)
+        rm -rf "$TEMP_DIR"
+    fi
+}
+
+exercise_path="$1"
+exercise_name=$(basename "$1")
+exercise_name=${exercise_name/-/_}
+
+trap cleanup_temp_dir EXIT INT TERM
+create_temp_dir
+
+echo "Checking exercise: $exercise_name"
+
+num_expected_tests=$(expected_number_of_tests)
+echo "    Expected number of tests    : $num_expected_tests"
+
+num_actual_tests=$(actual_number_of_tests)
+echo "    Actual number of tests      : $num_actual_tests"
+
+if [[ $num_expected_tests != $num_actual_tests ]]; then
+  echo "Number of expected and actual tests doesn't match!"
+  exit 1
+fi
+
+test_output=$(bin/run-test.sh "$exercise_path" 2>&1)
+if  [ $? -eq 0 ]; then
+  echo "    Running tests               : okay"
+else
+  echo "    Running tests:"
+  echo "$test_output"
+  exit 1
+fi
+
+# There is a weird bug where `odinfmt srcfile > outfile` inserts an extra trailing blank
+# line where `odinfmt -w srcfile` doesn't. This theows the formatting comparisons off.
+# For now, we will just copy srcfile to outfile and run `odinfmt -w` to compare
+# the files.
+# Long Term we need to figure out if there is a bug in odimfmt.
+
+# Another (simpler) solution would be to just reformat automatically as part of
+# `check-exercise.sh`
+
+#bin/odinfmt "${exercise_path}/${exercise_name}.odin" > "$TEMP_DIR/${exercise_name}.odin"
+cp "${exercise_path}/${exercise_name}.odin" "$TEMP_DIR/${exercise_name}.odin"
+bin/odinfmt -w "$TEMP_DIR/${exercise_name}.odin"
+stub_diffs=$(diff "${exercise_path}/${exercise_name}.odin" "$TEMP_DIR/${exercise_name}.odin" 2>&1)
+if [ $? -eq 0 ]; then
+  echo "    Exercise stub formatting    : okay"
+else
+  echo "${exercise_path}/${exercise_name}.odin is incorrectly formatted (run 'bin/odinfmt -w <filepath>'):"
+  echo $stub_diffs
+  exit 1
+fi
+
+#bin/odinfmt "${exercise_path}/${exercise_name}_test.odin" > "$TEMP_DIR/${exercise_name}_test.odin"
+cp "${exercise_path}/${exercise_name}_test.odin" "$TEMP_DIR/${exercise_name}_test.odin"
+bin/odinfmt -w "$TEMP_DIR/${exercise_name}_test.odin"
+test_diffs=$(diff "${exercise_path}/${exercise_name}_test.odin" "$TEMP_DIR/${exercise_name}_test.odin" 2>&1)
+if [ $? -eq 0 ]; then
+  echo "    Exercise tests formatting   : okay"
+else
+  echo "${exercise_path}/${exercise_name}_test.odin is incorrectly formatted (run 'bin/odinfmt -w <filepath>'):"
+  echo $test_diffs
+  exit 1
+fi
+
+#bin/odinfmt "${exercise_path}/.meta/example.odin" > "$TEMP_DIR/.meta/example.odin"
+cp "${exercise_path}/.meta/example.odin" "$TEMP_DIR/example.odin"
+bin/odinfmt -w  "$TEMP_DIR/example.odin"
+example_diffs=$(diff "${exercise_path}/.meta/example.odin" "$TEMP_DIR/example.odin" 2>&1)
+if [ $? -eq 0 ]; then
+  echo "    Exercise example formatting : okay"
+else
+  echo "${exercise_path}/.meta/example.odin is incorrectly formatted (run 'bin/odinfmt -w <filepath>'):"
+  echo $example_diffs
+  exit 1
+fi
+
+echo "Exercise $exercise_name pass all the checks!"

--- a/exercises/practice/acronym/.meta/example.odin
+++ b/exercises/practice/acronym/.meta/example.odin
@@ -16,7 +16,7 @@ abbreviate :: proc(phrase: string) -> string {
 	defer strings.builder_destroy(&buffer)
 	for {
 		capture, _, ok := regex.match_iterator(&iter)
-		if !ok {break}
+		if !ok { break }
 		first_letter := capture.groups[0][0]
 		strings.write_byte(&buffer, first_letter)
 	}

--- a/exercises/practice/atbash-cipher/.meta/example.odin
+++ b/exercises/practice/atbash-cipher/.meta/example.odin
@@ -13,7 +13,6 @@ decode :: proc(sentence: string) -> string {
 	return encode_by_block(sentence, 0)
 }
 
-
 encode_by_block :: proc(sentence: string, block_size: int) -> string {
 
 	// We are assuming the sentence is in ASCII (0-255).
@@ -33,7 +32,6 @@ encode_by_block :: proc(sentence: string, block_size: int) -> string {
 	}
 	return string(coded_sentence[:])
 }
-
 
 encode_letter :: proc(l: byte) -> (byte, bool) {
 

--- a/exercises/practice/bowling/bowling_test.odin
+++ b/exercises/practice/bowling/bowling_test.odin
@@ -140,7 +140,6 @@ test_consecutive_strikes_each_get_the_two_roll_bonus :: proc(t: ^testing.T) {
 @(test)
 test_a_strike_in_the_last_frame_gets_a_two_roll_bonus_that_is_counted_once :: proc(t: ^testing.T) {
 
-
 	game := new_game()
 	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1}
 	apply_previous_rolls(t, &game, rolls[:])
@@ -230,7 +229,6 @@ test_rolls_cannot_score_negative_points :: proc(t: ^testing.T) {
 @(test)
 test_a_roll_cannot_score_more_than_10_points :: proc(t: ^testing.T) {
 
-
 	game := new_game()
 	error := roll(&game, 11)
 
@@ -293,7 +291,6 @@ test_two_bonus_rolls_after_a_strike_in_the_last_frame_can_score_more_than_10_poi
 test_the_second_bonus_rolls_after_a_strike_in_the_last_frame_cannot_be_a_strike_if_the_first_one_is_not_a_strike :: proc(
 	t: ^testing.T,
 ) {
-
 
 	game := new_game()
 	rolls := [?]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6}

--- a/exercises/practice/circular-buffer/.meta/example.odin
+++ b/exercises/practice/circular-buffer/.meta/example.odin
@@ -52,7 +52,6 @@ write :: proc(b: ^Buffer, value: int) -> Error {
 	return .None
 }
 
-
 overwrite :: proc(b: ^Buffer, value: int) {
 
 	if b.size == len(b.elements) {

--- a/exercises/practice/circular-buffer/circular_buffer.odin
+++ b/exercises/practice/circular-buffer/circular_buffer.odin
@@ -26,7 +26,6 @@ write :: proc(b: ^Buffer, value: int) -> Error {
 	#panic("implement this procedure")
 }
 
-
 overwrite :: proc(b: ^Buffer, value: int) {
 	#panic("implement this procedure")
 }

--- a/exercises/practice/circular-buffer/circular_buffer_test.odin
+++ b/exercises/practice/circular-buffer/circular_buffer_test.odin
@@ -99,9 +99,7 @@ test_a_read_frees_up_capacity_for_another_write :: proc(t: ^testing.T) {
 }
 
 @(test)
-test_read_position_is_maintained_even_across_multiple_writes :: proc(
-	t: ^testing.T,
-) {
+test_read_position_is_maintained_even_across_multiple_writes :: proc(t: ^testing.T) {
 
 	buffer := new_buffer(3)
 	defer destroy_buffer(&buffer)

--- a/exercises/practice/grains/grains.odin
+++ b/exercises/practice/grains/grains.odin
@@ -2,7 +2,6 @@ package grains
 
 Error :: enum {} // Please inspect the tests to see which error states to enumerate here.
 
-
 // Returns the number of grains on the specified square.
 square :: proc(n: int) -> (u64, Error) {
 	#panic("Please implement the `square` procedure.")

--- a/exercises/practice/grains/grains_test.odin
+++ b/exercises/practice/grains/grains_test.odin
@@ -3,63 +3,49 @@ package grains
 import "core:testing"
 
 @(test)
-test_returns_the_number_of_grains_on_the_square_grains_on_square_1 :: proc(
-	t: ^testing.T,
-) {
+test_returns_the_number_of_grains_on_the_square_grains_on_square_1 :: proc(t: ^testing.T) {
 	c, e := square(1)
 	testing.expect_value(t, c, 1)
 	testing.expect_value(t, e, Error.None)
 }
 
 @(test)
-test_returns_the_number_of_grains_on_the_square_grains_on_square_2 :: proc(
-	t: ^testing.T,
-) {
+test_returns_the_number_of_grains_on_the_square_grains_on_square_2 :: proc(t: ^testing.T) {
 	c, e := square(2)
 	testing.expect_value(t, c, 2)
 	testing.expect_value(t, e, Error.None)
 }
 
 @(test)
-test_returns_the_number_of_grains_on_the_square_grains_on_square_3 :: proc(
-	t: ^testing.T,
-) {
+test_returns_the_number_of_grains_on_the_square_grains_on_square_3 :: proc(t: ^testing.T) {
 	c, e := square(3)
 	testing.expect_value(t, c, 4)
 	testing.expect_value(t, e, Error.None)
 }
 
 @(test)
-test_returns_the_number_of_grains_on_the_square_grains_on_square_4 :: proc(
-	t: ^testing.T,
-) {
+test_returns_the_number_of_grains_on_the_square_grains_on_square_4 :: proc(t: ^testing.T) {
 	c, e := square(4)
 	testing.expect_value(t, c, 8)
 	testing.expect_value(t, e, Error.None)
 }
 
 @(test)
-test_returns_the_number_of_grains_on_the_square_grains_on_square_16 :: proc(
-	t: ^testing.T,
-) {
+test_returns_the_number_of_grains_on_the_square_grains_on_square_16 :: proc(t: ^testing.T) {
 	c, e := square(16)
 	testing.expect_value(t, c, 32_768)
 	testing.expect_value(t, e, Error.None)
 }
 
 @(test)
-test_returns_the_number_of_grains_on_the_square_grains_on_square_32 :: proc(
-	t: ^testing.T,
-) {
+test_returns_the_number_of_grains_on_the_square_grains_on_square_32 :: proc(t: ^testing.T) {
 	c, e := square(32)
 	testing.expect_value(t, c, 2_147_483_648)
 	testing.expect_value(t, e, Error.None)
 }
 
 @(test)
-test_returns_the_number_of_grains_on_the_square_grains_on_square_64 :: proc(
-	t: ^testing.T,
-) {
+test_returns_the_number_of_grains_on_the_square_grains_on_square_64 :: proc(t: ^testing.T) {
 	c, e := square(64)
 	testing.expect_value(t, c, 9_223_372_036_854_775_808)
 	testing.expect_value(t, e, Error.None)

--- a/exercises/practice/high-scores/.meta/example.odin
+++ b/exercises/practice/high-scores/.meta/example.odin
@@ -11,7 +11,6 @@ High_Scores :: struct {
 	values: [dynamic]int,
 }
 
-
 new_scores :: proc(initial_values: []int) -> High_Scores {
 
 	scores: High_Scores
@@ -19,12 +18,10 @@ new_scores :: proc(initial_values: []int) -> High_Scores {
 	return scores
 }
 
-
 destroy_scores :: proc(s: ^High_Scores) {
 
 	delete(s.values)
 }
-
 
 scores :: proc(s: High_Scores) -> []int {
 
@@ -35,7 +32,6 @@ scores :: proc(s: High_Scores) -> []int {
 	return scores
 }
 
-
 latest :: proc(s: High_Scores) -> int {
 
 	if len(s.values) == 0 {
@@ -43,7 +39,6 @@ latest :: proc(s: High_Scores) -> int {
 	}
 	return s.values[len(s.values) - 1]
 }
-
 
 personal_best :: proc(s: High_Scores) -> int {
 
@@ -56,7 +51,6 @@ personal_best :: proc(s: High_Scores) -> int {
 	}
 	return best
 }
-
 
 personal_top_three :: proc(s: High_Scores) -> []int {
 

--- a/exercises/practice/leap/leap_test.odin
+++ b/exercises/practice/leap/leap_test.odin
@@ -23,16 +23,12 @@ test_divisible_by_4_and_5_is_still_a_leap_year :: proc(t: ^testing.T) {
 }
 
 @(test)
-test_divisible_by_100_not_divisible_by_400_in_common_year :: proc(
-	t: ^testing.T,
-) {
+test_divisible_by_100_not_divisible_by_400_in_common_year :: proc(t: ^testing.T) {
 	testing.expect(t, !is_leap_year(2100))
 }
 
 @(test)
-test_divisible_by_100_but_not_by_3_is_still_not_a_leap_year :: proc(
-	t: ^testing.T,
-) {
+test_divisible_by_100_but_not_by_3_is_still_not_a_leap_year :: proc(t: ^testing.T) {
 	testing.expect(t, !is_leap_year(1900))
 }
 
@@ -42,15 +38,11 @@ test_divisible_by_400 :: proc(t: ^testing.T) {
 }
 
 @(test)
-test_divisible_by_400_but_not_by_125_is_still_a_leap_year :: proc(
-	t: ^testing.T,
-) {
+test_divisible_by_400_but_not_by_125_is_still_a_leap_year :: proc(t: ^testing.T) {
 	testing.expect(t, is_leap_year(2400))
 }
 
 @(test)
-test_divisible_by_200_not_divisible_by_400_in_common_year :: proc(
-	t: ^testing.T,
-) {
+test_divisible_by_200_not_divisible_by_400_in_common_year :: proc(t: ^testing.T) {
 	testing.expect(t, !is_leap_year(1800))
 }

--- a/exercises/practice/resistor-color/.meta/example.odin
+++ b/exercises/practice/resistor-color/.meta/example.odin
@@ -18,16 +18,5 @@ code :: proc(color: Color) -> int {
 }
 
 colors :: proc() -> [10]Color {
-	return [10]Color {
-		.Black,
-		.Brown,
-		.Red,
-		.Orange,
-		.Yellow,
-		.Green,
-		.Blue,
-		.Violet,
-		.Grey,
-		.White,
-	}
+	return [10]Color{.Black, .Brown, .Red, .Orange, .Yellow, .Green, .Blue, .Violet, .Grey, .White}
 }

--- a/exercises/practice/resistor-color/resistor_color.odin
+++ b/exercises/practice/resistor-color/resistor_color.odin
@@ -2,7 +2,6 @@ package resistor_color
 
 Color :: enum {} // Implement an enumeration of all the resistor colors.
 
-
 code :: proc(color: Color) -> int {
 	#panic("Please implement the `code` procedure.")
 }

--- a/exercises/practice/resistor-color/resistor_color_test.odin
+++ b/exercises/practice/resistor-color/resistor_color_test.odin
@@ -57,17 +57,6 @@ all_colors :: proc(t: ^testing.T) {
 	testing.expect_value(
 		t,
 		colors(),
-		[10]Color {
-			.Black,
-			.Brown,
-			.Red,
-			.Orange,
-			.Yellow,
-			.Green,
-			.Blue,
-			.Violet,
-			.Grey,
-			.White,
-		},
+		[10]Color{.Black, .Brown, .Red, .Orange, .Yellow, .Green, .Blue, .Violet, .Grey, .White},
 	)
 }

--- a/exercises/practice/roman-numerals/roman_numerals_test.odin
+++ b/exercises/practice/roman-numerals/roman_numerals_test.odin
@@ -71,7 +71,6 @@ test_9_is_ix :: proc(t: ^testing.T) {
 	result := to_roman_numeral(decimal)
 	defer delete(result)
 
-
 	testing.expect_value(t, result, expected)
 }
 

--- a/exercises/practice/two-bucket/.meta/example.odin
+++ b/exercises/practice/two-bucket/.meta/example.odin
@@ -54,13 +54,7 @@ isValid :: proc(bucket_one: int, bucket_two: int, goal: int) -> bool {
 	return true
 }
 
-go_measure :: proc(
-	start: ^Bucket,
-	other: ^Bucket,
-	goal: int,
-) -> (
-	result: Result,
-) {
+go_measure :: proc(start: ^Bucket, other: ^Bucket, goal: int) -> (result: Result) {
 	moves := 0
 
 	fill(start)

--- a/exercises/practice/two-bucket/two_bucket_test.odin
+++ b/exercises/practice/two-bucket/two_bucket_test.odin
@@ -7,12 +7,7 @@ test_measure_using_bucket_one_of_size_3_and_bucket_two_of_size_5___start_with_bu
 	t: ^testing.T,
 ) {
 
-	result, valid := measure(
-		bucket_one = 3,
-		bucket_two = 5,
-		goal = 1,
-		start_bucket = "one",
-	)
+	result, valid := measure(bucket_one = 3, bucket_two = 5, goal = 1, start_bucket = "one")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 4)
@@ -25,12 +20,7 @@ test_measure_using_bucket_one_of_size_3_and_bucket_two_of_size_5___start_with_bu
 	t: ^testing.T,
 ) {
 
-	result, valid := measure(
-		bucket_one = 3,
-		bucket_two = 5,
-		goal = 1,
-		start_bucket = "two",
-	)
+	result, valid := measure(bucket_one = 3, bucket_two = 5, goal = 1, start_bucket = "two")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 8)
@@ -43,12 +33,7 @@ test_measure_using_bucket_one_of_size_7_and_bucket_two_of_size_11___start_with_b
 	t: ^testing.T,
 ) {
 
-	result, valid := measure(
-		bucket_one = 7,
-		bucket_two = 11,
-		goal = 2,
-		start_bucket = "one",
-	)
+	result, valid := measure(bucket_one = 7, bucket_two = 11, goal = 2, start_bucket = "one")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 14)
@@ -61,12 +46,7 @@ test_measure_using_bucket_one_of_size_7_and_bucket_two_of_size_11___start_with_b
 	t: ^testing.T,
 ) {
 
-	result, valid := measure(
-		bucket_one = 7,
-		bucket_two = 11,
-		goal = 2,
-		start_bucket = "two",
-	)
+	result, valid := measure(bucket_one = 7, bucket_two = 11, goal = 2, start_bucket = "two")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 18)
@@ -79,12 +59,7 @@ test_measure_one_step_using_bucket_one_of_size_1_and_bucket_two_of_size_3___star
 	t: ^testing.T,
 ) {
 
-	result, valid := measure(
-		bucket_one = 1,
-		bucket_two = 3,
-		goal = 3,
-		start_bucket = "two",
-	)
+	result, valid := measure(bucket_one = 1, bucket_two = 3, goal = 3, start_bucket = "two")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 1)
@@ -97,12 +72,7 @@ test_measure_using_bucket_one_of_size_2_and_bucket_two_of_size_3___start_with_bu
 	t: ^testing.T,
 ) {
 
-	result, valid := measure(
-		bucket_one = 2,
-		bucket_two = 3,
-		goal = 3,
-		start_bucket = "one",
-	)
+	result, valid := measure(bucket_one = 2, bucket_two = 3, goal = 3, start_bucket = "one")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 2)
@@ -111,16 +81,9 @@ test_measure_using_bucket_one_of_size_2_and_bucket_two_of_size_3___start_with_bu
 }
 
 @(test)
-test_measure_using_bucket_one_much_bigger_than_bucket_two :: proc(
-	t: ^testing.T,
-) {
+test_measure_using_bucket_one_much_bigger_than_bucket_two :: proc(t: ^testing.T) {
 
-	result, valid := measure(
-		bucket_one = 5,
-		bucket_two = 1,
-		goal = 2,
-		start_bucket = "one",
-	)
+	result, valid := measure(bucket_one = 5, bucket_two = 1, goal = 2, start_bucket = "one")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 6)
@@ -129,16 +92,9 @@ test_measure_using_bucket_one_much_bigger_than_bucket_two :: proc(
 }
 
 @(test)
-test_measure_using_bucket_one_much_smaller_than_bucket_two :: proc(
-	t: ^testing.T,
-) {
+test_measure_using_bucket_one_much_smaller_than_bucket_two :: proc(t: ^testing.T) {
 
-	result, valid := measure(
-		bucket_one = 3,
-		bucket_two = 15,
-		goal = 9,
-		start_bucket = "one",
-	)
+	result, valid := measure(bucket_one = 3, bucket_two = 15, goal = 9, start_bucket = "one")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 6)
@@ -149,27 +105,15 @@ test_measure_using_bucket_one_much_smaller_than_bucket_two :: proc(
 @(test)
 test_not_possible_to_reach_the_goal :: proc(t: ^testing.T) {
 
-	_, valid := measure(
-		bucket_one = 6,
-		bucket_two = 15,
-		goal = 5,
-		start_bucket = "one",
-	)
+	_, valid := measure(bucket_one = 6, bucket_two = 15, goal = 5, start_bucket = "one")
 
 	testing.expect_value(t, valid, false)
 }
 
 @(test)
-test_with_the_same_buckets_but_a_different_goal_then_it_is_possible :: proc(
-	t: ^testing.T,
-) {
+test_with_the_same_buckets_but_a_different_goal_then_it_is_possible :: proc(t: ^testing.T) {
 
-	result, valid := measure(
-		bucket_one = 6,
-		bucket_two = 15,
-		goal = 9,
-		start_bucket = "one",
-	)
+	result, valid := measure(bucket_one = 6, bucket_two = 15, goal = 9, start_bucket = "one")
 
 	testing.expect_value(t, valid, true)
 	testing.expect_value(t, result.moves, 10)
@@ -180,12 +124,7 @@ test_with_the_same_buckets_but_a_different_goal_then_it_is_possible :: proc(
 @(test)
 test_goal_larger_than_both_buckets_is_impossible :: proc(t: ^testing.T) {
 
-	_, valid := measure(
-		bucket_one = 5,
-		bucket_two = 7,
-		goal = 8,
-		start_bucket = "one",
-	)
+	_, valid := measure(bucket_one = 5, bucket_two = 7, goal = 8, start_bucket = "one")
 
 	testing.expect_value(t, valid, false)
 }

--- a/src/odin_code_generator.odin
+++ b/src/odin_code_generator.odin
@@ -68,45 +68,16 @@ generate_function :: proc(b: ^strings.Builder, i: int, function: Function) {
 	}
 
 	w(b, i, true, `) -> {{`)
-	w(
-		b,
-		i + 1,
-		true,
-		`{}: {} = {}`,
-		function.ret.name,
-		function.ret.type,
-		function.ret.value,
-	)
+	w(b, i + 1, true, `{}: {} = {}`, function.ret.name, function.ret.type, function.ret.value)
 	w(b, i + 1, true, `return {}`, function.ret.name)
 	w(b, i, true, `}}`)
 }
 
-generate_argument :: proc(
-	b: ^strings.Builder,
-	i: int,
-	newline: bool,
-	argument: Argument,
-) {
+generate_argument :: proc(b: ^strings.Builder, i: int, newline: bool, argument: Argument) {
 	if argument.type == "string" {
-		w(
-			b,
-			i,
-			newline,
-			`{}: {} = "{}"`,
-			argument.name,
-			argument.type,
-			argument.value,
-		)
+		w(b, i, newline, `{}: {} = "{}"`, argument.name, argument.type, argument.value)
 	} else {
-		w(
-			b,
-			i,
-			newline,
-			`{}: {} = {}`,
-			argument.name,
-			argument.type,
-			argument.value,
-		)
+		w(b, i, newline, `{}: {} = {}`, argument.name, argument.type, argument.value)
 	}
 }
 
@@ -140,13 +111,7 @@ generate_test :: proc(b: ^strings.Builder, i: int, test: Test) {
 }
 
 // Write
-w :: proc(
-	b: ^strings.Builder,
-	ind := 0,
-	newline := true,
-	format: string,
-	args: ..any,
-) {
+w :: proc(b: ^strings.Builder, ind := 0, newline := true, format: string, args: ..any) {
 	indent(b, ind)
 	fmt.sbprintf(b, format, ..args)
 


### PR DESCRIPTION
The check-exercise.sh checks:
- the number of tests defined in `tests.toml` matches the number defined in `<exercise-slug>_test.odin`.
- The example solution passes all the tests
- The stub solution fails all the tests
- The stub solution, test, and example files are properly formatted

 The PR also include formatting changes to the existing odin
 file obtained from running `bin/format-all.sh` with the latest
 `odinfmt.json` file. This is a one time change if contributors
 run `check-exercise.sh` before pushing a PR from now on.

[no important files changed]