### PR TITLE
Add tool to create scaffolding for concept (Follow up to PR #89)

### DIFF
--- a/bin/gen-concept.sh
+++ b/bin/gen-concept.sh
@@ -26,7 +26,7 @@ read -rp 'What is the concept blurb? ' blurb
 
 concept_name=$1
 concept_slug=$(to_snake_case <<< "$concept_name")
-conceptpath="concepts/${concept_slug}"
+concept_path="concepts/${concept_slug}"
 
 if [[ -d "$concept_path" ]]; then
   die "Concept ${concept_name} directory already exist!"
@@ -147,5 +147,5 @@ jq \
 echo "Be sure to implement the following files:"
 echo -e "\t${concept_path}/introduction.md"
 echo -e "\t${concept_path}/about.md"
-echo -e "\t${concept_path}/hint.md"
+echo -e "\t${concept_path}/links.json"
 echo ""


### PR DESCRIPTION
We currently have a tool to generate scaffolding for a concept exercise (gen-exercise.sh as of PR #89) but no tool to create the concept itself.

Configlet doesn't provide such an option either.

This tool is modeled after gen-exercise and will create all the files required for a concept with some comments describing what each file should contain (similar to the raw versions of the files in the top-level 'docs/' folder of the track). It will also add the concept information to the top-level `config.json`.

There was also a mis-formatting in config.json, this was corrected here so it doesn't show up in the next unrelated exercise pull request.