### PR TITLE
Revert tests to using expect_slices_match

### DIFF
--- a/exercises/practice/forth/forth_test.odin
+++ b/exercises/practice/forth/forth_test.odin
@@ -3,16 +3,15 @@ package forth
 import "core:fmt"
 import "core:testing"
 
-expect_value_as_string :: proc(
-	t: ^testing.T,
-	actual: $T,
-	expected: string,
-	loc := #caller_location,
-) {
+expect_slices_match :: proc(t: ^testing.T, actual, expected: []$E, loc := #caller_location) {
 	result := fmt.aprintf("%v", actual)
-	delete(result)
+	exp_str := fmt.aprintf("%v", expected)
+	defer {
+		delete(result)
+		delete(exp_str)
+	}
 
-	testing.expect_value(t, result[1:len(result) - 1], expected)
+	testing.expect_value(t, result, exp_str)
 }
 
 @(test)
@@ -22,7 +21,7 @@ test_parsing_and_numbers__numbers_just_get_pushed_onto_the_stack :: proc(t: ^tes
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 2, 3, 4, 5")
+	expect_slices_match(t, result, []int{1, 2, 3, 4, 5})
 }
 
 @(test)
@@ -32,7 +31,7 @@ test_parsing_and_numbers__pushes_negative_numbers_onto_the_stack :: proc(t: ^tes
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "-1, -2, -3, -4, -5")
+	expect_slices_match(t, result, []int{-1, -2, -3, -4, -5})
 }
 
 @(test)
@@ -42,7 +41,7 @@ test_addition__can_add_two_numbers :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "3")
+	expect_slices_match(t, result, []int{3})
 }
 
 @(test)
@@ -70,7 +69,7 @@ test_addition__more_than_two_values_on_the_stack :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 5")
+	expect_slices_match(t, result, []int{1, 5})
 }
 
 @(test)
@@ -80,7 +79,7 @@ test_subtraction__can_subtract_two_numbers :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "-1")
+	expect_slices_match(t, result, []int{-1})
 }
 
 @(test)
@@ -108,7 +107,7 @@ test_subtraction__more_than_two_values_on_the_stack :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 9")
+	expect_slices_match(t, result, []int{1, 9})
 }
 
 @(test)
@@ -118,7 +117,7 @@ test_multiplication__can_multiply_two_numbers :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "8")
+	expect_slices_match(t, result, []int{8})
 }
 
 @(test)
@@ -146,7 +145,7 @@ test_multiplication__more_than_two_values_on_the_stack :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 6")
+	expect_slices_match(t, result, []int{1, 6})
 }
 
 @(test)
@@ -156,7 +155,7 @@ test_division__can_divide_two_numbers :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "4")
+	expect_slices_match(t, result, []int{4})
 }
 
 @(test)
@@ -166,7 +165,7 @@ test_division__performs_integer_division :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "2")
+	expect_slices_match(t, result, []int{2})
 }
 
 @(test)
@@ -203,7 +202,7 @@ test_division__more_than_two_values_on_the_stack :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 4")
+	expect_slices_match(t, result, []int{1, 4})
 }
 
 @(test)
@@ -213,7 +212,7 @@ test_combined_arithmetic__addition_and_subtraction :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "-1")
+	expect_slices_match(t, result, []int{-1})
 }
 
 @(test)
@@ -223,7 +222,7 @@ test_combined_arithmetic__multiplication_and_division :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "2")
+	expect_slices_match(t, result, []int{2})
 }
 
 @(test)
@@ -233,7 +232,7 @@ test_combined_arithmetic__multiplication_and_addition :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "13")
+	expect_slices_match(t, result, []int{13})
 }
 
 @(test)
@@ -243,7 +242,7 @@ test_combined_arithmetic__addition_and_multiplication :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "7")
+	expect_slices_match(t, result, []int{7})
 }
 
 @(test)
@@ -253,7 +252,7 @@ test_dup__copies_a_value_on_the_stack :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 1")
+	expect_slices_match(t, result, []int{1, 1})
 }
 
 @(test)
@@ -263,7 +262,7 @@ test_dup__copies_the_top_value_on_the_stack :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 2, 2")
+	expect_slices_match(t, result, []int{1, 2, 2})
 }
 
 @(test)
@@ -282,7 +281,7 @@ test_drop__removes_the_top_value_on_the_stack_if_it_is_the_only_one :: proc(t: ^
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "")
+	expect_slices_match(t, result, []int{})
 }
 
 @(test)
@@ -292,7 +291,7 @@ test_drop__removes_the_top_value_on_the_stack_if_it_is_not_the_only_one :: proc(
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1")
+	expect_slices_match(t, result, []int{1})
 }
 
 @(test)
@@ -311,7 +310,7 @@ test_swap__swaps_the_top_two_values_on_the_stack_if_they_are_the_only_ones :: pr
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "2, 1")
+	expect_slices_match(t, result, []int{2, 1})
 }
 
 @(test)
@@ -323,7 +322,7 @@ test_swap__swaps_the_top_two_values_on_the_stack_if_they_are_not_the_only_ones :
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 3, 2")
+	expect_slices_match(t, result, []int{1, 3, 2})
 }
 
 @(test)
@@ -351,7 +350,7 @@ test_over__copies_the_second_element_if_there_are_only_two :: proc(t: ^testing.T
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 2, 1")
+	expect_slices_match(t, result, []int{1, 2, 1})
 }
 
 @(test)
@@ -361,7 +360,7 @@ test_over__copies_the_second_element_if_there_are_more_than_two :: proc(t: ^test
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 2, 3, 2")
+	expect_slices_match(t, result, []int{1, 2, 3, 2})
 }
 
 @(test)
@@ -389,7 +388,7 @@ test_user_defined_words__can_consist_of_built_in_words :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 1, 1")
+	expect_slices_match(t, result, []int{1, 1, 1})
 }
 
 @(test)
@@ -399,7 +398,7 @@ test_user_defined_words__execute_in_the_right_order :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 2, 3")
+	expect_slices_match(t, result, []int{1, 2, 3})
 }
 
 @(test)
@@ -409,7 +408,7 @@ test_user_defined_words__can_override_other_user_defined_words :: proc(t: ^testi
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 1, 1")
+	expect_slices_match(t, result, []int{1, 1, 1})
 }
 
 @(test)
@@ -419,7 +418,7 @@ test_user_defined_words__can_override_built_in_words :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 1")
+	expect_slices_match(t, result, []int{1, 1})
 }
 
 @(test)
@@ -429,7 +428,7 @@ test_user_defined_words__can_override_built_in_operators :: proc(t: ^testing.T) 
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "12")
+	expect_slices_match(t, result, []int{12})
 }
 
 @(test)
@@ -439,7 +438,7 @@ test_user_defined_words__can_use_different_words_with_the_same_name :: proc(t: ^
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "5, 6")
+	expect_slices_match(t, result, []int{5, 6})
 }
 
 @(test)
@@ -449,7 +448,7 @@ test_user_defined_words__can_define_word_that_uses_word_with_the_same_name :: pr
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "11")
+	expect_slices_match(t, result, []int{11})
 }
 
 @(test)
@@ -486,13 +485,13 @@ test_user_defined_words__only_defines_locally :: proc(t: ^testing.T) {
 	defer delete(result1)
 
 	testing.expect_value(t, error1, Error.None)
-	expect_value_as_string(t, result1, "0")
+	expect_slices_match(t, result1, []int{0})
 
 	result2, error2 := evaluate("1 1 +")
 	defer delete(result2)
 
 	testing.expect_value(t, error2, Error.None)
-	expect_value_as_string(t, result2, "2")
+	expect_slices_match(t, result2, []int{2})
 }
 
 @(test)
@@ -502,7 +501,7 @@ test_case_insensitivity__dup_is_case_insensitive :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 1, 1, 1")
+	expect_slices_match(t, result, []int{1, 1, 1, 1})
 }
 
 @(test)
@@ -512,7 +511,7 @@ test_case_insensitivity__drop_is_case_insensitive :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1")
+	expect_slices_match(t, result, []int{1})
 }
 
 @(test)
@@ -522,7 +521,7 @@ test_case_insensitivity__swap_is_case_insensitive :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "2, 3, 4, 1")
+	expect_slices_match(t, result, []int{2, 3, 4, 1})
 }
 
 @(test)
@@ -532,7 +531,7 @@ test_case_insensitivity__over_is_case_insensitive :: proc(t: ^testing.T) {
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 2, 1, 2, 1")
+	expect_slices_match(t, result, []int{1, 2, 1, 2, 1})
 }
 
 @(test)
@@ -542,7 +541,7 @@ test_case_insensitivity__user_defined_words_are_case_insensitive :: proc(t: ^tes
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 1, 1, 1")
+	expect_slices_match(t, result, []int{1, 1, 1, 1})
 }
 
 @(test)
@@ -552,5 +551,5 @@ test_case_insensitivity__definitions_are_case_insensitive :: proc(t: ^testing.T)
 	defer delete(result)
 
 	testing.expect_value(t, error, Error.None)
-	expect_value_as_string(t, result, "1, 1, 1, 1")
+	expect_slices_match(t, result, []int{1, 1, 1, 1})
 }

--- a/exercises/practice/protein-translation/protein_translation_test.odin
+++ b/exercises/practice/protein-translation/protein_translation_test.odin
@@ -3,17 +3,15 @@ package protein_translation
 import "core:fmt"
 import "core:testing"
 
-expect_value_as_string :: proc(
-	t: ^testing.T,
-	value: $T,
-	expected: string,
-	loc := #caller_location,
-) {
+expect_slices_match :: proc(t: ^testing.T, actual, expected: []$E, loc := #caller_location) {
+	result := fmt.aprintf("%v", actual)
+	exp_str := fmt.aprintf("%v", expected)
+	defer {
+		delete(result)
+		delete(exp_str)
+	}
 
-	result := fmt.aprintf("%v", value)
-	defer delete(result)
-
-	testing.expect_value(t, result, expected, loc = loc)
+	testing.expect_value(t, result, exp_str)
 }
 
 @(test)
@@ -22,7 +20,7 @@ test_empty_rna_sequence_results_in_no_proteins :: proc(t: ^testing.T) {
 	result, ok := proteins("")
 	defer delete(result)
 
-	expect_value_as_string(t, result, "[]")
+	expect_slices_match(t, result, []string{})
 	testing.expect_value(t, ok, true)
 }
 
@@ -32,7 +30,7 @@ test_methionine_rna_sequence :: proc(t: ^testing.T) {
 	result, ok := proteins("AUG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Methionine"]`)
+	expect_slices_match(t, result, []string{"Methionine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -42,7 +40,7 @@ test_phenylalanine_rna_sequence_1 :: proc(t: ^testing.T) {
 	result, ok := proteins("UUU")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Phenylalanine"]`)
+	expect_slices_match(t, result, []string{"Phenylalanine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -52,7 +50,7 @@ test_phenylalanine_rna_sequence_2 :: proc(t: ^testing.T) {
 	result, ok := proteins("UUC")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Phenylalanine"]`)
+	expect_slices_match(t, result, []string{"Phenylalanine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -62,7 +60,7 @@ test_leucine_rna_sequence_1 :: proc(t: ^testing.T) {
 	result, ok := proteins("UUA")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Leucine"]`)
+	expect_slices_match(t, result, []string{"Leucine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -72,7 +70,7 @@ test_leucine_rna_sequence_2 :: proc(t: ^testing.T) {
 	result, ok := proteins("UUG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Leucine"]`)
+	expect_slices_match(t, result, []string{"Leucine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -82,7 +80,7 @@ test_serine_rna_sequence_1 :: proc(t: ^testing.T) {
 	result, ok := proteins("UCU")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Serine"]`)
+	expect_slices_match(t, result, []string{"Serine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -92,7 +90,7 @@ test_serine_rna_sequence_2 :: proc(t: ^testing.T) {
 	result, ok := proteins("UCC")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Serine"]`)
+	expect_slices_match(t, result, []string{"Serine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -102,7 +100,7 @@ test_serine_rna_sequence_3 :: proc(t: ^testing.T) {
 	result, ok := proteins("UCA")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Serine"]`)
+	expect_slices_match(t, result, []string{"Serine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -112,7 +110,7 @@ test_serine_rna_sequence_4 :: proc(t: ^testing.T) {
 	result, ok := proteins("UCG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Serine"]`)
+	expect_slices_match(t, result, []string{"Serine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -122,7 +120,7 @@ test_tyrosine_rna_sequence_1 :: proc(t: ^testing.T) {
 	result, ok := proteins("UAU")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Tyrosine"]`)
+	expect_slices_match(t, result, []string{"Tyrosine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -132,7 +130,7 @@ test_tyrosine_rna_sequence_2 :: proc(t: ^testing.T) {
 	result, ok := proteins("UAC")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Tyrosine"]`)
+	expect_slices_match(t, result, []string{"Tyrosine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -142,7 +140,7 @@ test_cysteine_rna_sequence_1 :: proc(t: ^testing.T) {
 	result, ok := proteins("UGU")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Cysteine"]`)
+	expect_slices_match(t, result, []string{"Cysteine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -152,7 +150,7 @@ test_cysteine_rna_sequence_2 :: proc(t: ^testing.T) {
 	result, ok := proteins("UGC")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Cysteine"]`)
+	expect_slices_match(t, result, []string{"Cysteine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -162,7 +160,7 @@ test_tryptophan_rna_sequence :: proc(t: ^testing.T) {
 	result, ok := proteins("UGG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Tryptophan"]`)
+	expect_slices_match(t, result, []string{"Tryptophan"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -172,7 +170,7 @@ test_stop_codon_rna_sequence_1 :: proc(t: ^testing.T) {
 	result, ok := proteins("UAA")
 	defer delete(result)
 
-	expect_value_as_string(t, result, "[]")
+	expect_slices_match(t, result, []string{})
 	testing.expect_value(t, ok, true)
 }
 
@@ -182,7 +180,7 @@ test_stop_codon_rna_sequence_2 :: proc(t: ^testing.T) {
 	result, ok := proteins("UAG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, "[]")
+	expect_slices_match(t, result, []string{})
 	testing.expect_value(t, ok, true)
 }
 
@@ -192,7 +190,7 @@ test_stop_codon_rna_sequence_3 :: proc(t: ^testing.T) {
 	result, ok := proteins("UGA")
 	defer delete(result)
 
-	expect_value_as_string(t, result, "[]")
+	expect_slices_match(t, result, []string{})
 	testing.expect_value(t, ok, true)
 }
 
@@ -202,7 +200,7 @@ test_sequence_of_two_protein_codons_translates_into_proteins :: proc(t: ^testing
 	result, ok := proteins("UUUUUU")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Phenylalanine", "Phenylalanine"]`)
+	expect_slices_match(t, result, []string{"Phenylalanine", "Phenylalanine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -212,7 +210,7 @@ test_sequence_of_two_different_protein_codons_translates_into_proteins :: proc(t
 	result, ok := proteins("UUAUUG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Leucine", "Leucine"]`)
+	expect_slices_match(t, result, []string{"Leucine", "Leucine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -222,7 +220,7 @@ test_translate_rna_strand_into_correct_protein_list :: proc(t: ^testing.T) {
 	result, ok := proteins("AUGUUUUGG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Methionine", "Phenylalanine", "Tryptophan"]`)
+	expect_slices_match(t, result, []string{"Methionine", "Phenylalanine", "Tryptophan"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -232,7 +230,7 @@ test_translation_stops_if_stop_codon_at_beginning_of_sequence :: proc(t: ^testin
 	result, ok := proteins("UAGUGG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, "[]")
+	expect_slices_match(t, result, []string{})
 	testing.expect_value(t, ok, true)
 }
 
@@ -242,7 +240,7 @@ test_translation_stops_if_stop_codon_at_end_of_two_codon_sequence :: proc(t: ^te
 	result, ok := proteins("UGGUAG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Tryptophan"]`)
+	expect_slices_match(t, result, []string{"Tryptophan"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -252,7 +250,7 @@ test_translation_stops_if_stop_codon_at_end_of_three_codon_sequence :: proc(t: ^
 	result, ok := proteins("AUGUUUUAA")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Methionine", "Phenylalanine"]`)
+	expect_slices_match(t, result, []string{"Methionine", "Phenylalanine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -262,7 +260,7 @@ test_translation_stops_if_stop_codon_in_middle_of_three_codon_sequence :: proc(t
 	result, ok := proteins("UGGUAGUGG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Tryptophan"]`)
+	expect_slices_match(t, result, []string{"Tryptophan"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -272,7 +270,7 @@ test_translation_stops_if_stop_codon_in_middle_of_six_codon_sequence :: proc(t: 
 	result, ok := proteins("UGGUGUUAUUAAUGGUUU")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Tryptophan", "Cysteine", "Tyrosine"]`)
+	expect_slices_match(t, result, []string{"Tryptophan", "Cysteine", "Tyrosine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -282,7 +280,7 @@ test_sequence_of_two_non_stop_codons_does_not_translate_to_a_stop_codon :: proc(
 	result, ok := proteins("AUGAUG")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Methionine", "Methionine"]`)
+	expect_slices_match(t, result, []string{"Methionine", "Methionine"})
 	testing.expect_value(t, ok, true)
 }
 
@@ -310,6 +308,6 @@ test_incomplete_rna_sequence_can_translate_if_valid_until_a_stop_codon :: proc(t
 	result, ok := proteins("UUCUUCUAAUGGU")
 	defer delete(result)
 
-	expect_value_as_string(t, result, `["Phenylalanine", "Phenylalanine"]`)
+	expect_slices_match(t, result, []string{"Phenylalanine", "Phenylalanine"})
 	testing.expect_value(t, ok, true)
 }


### PR DESCRIPTION
Replaced the expect_value_as_string() with expect_slices_match.

Reverted both the Forth exercise and the Protein Translation exercise.

[no important files changed]