### PR TITLE
populate shared exercise docs

### DIFF
--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,21 +1,10 @@
 # Help
 
-<!-- TODO: write document
+## Need more help?
 
-  This document should contain track-specific instructions on how to get help when
-  the student is stuck.
-
-  The instructions should be short and to the point.
-
-  You could link to resources like Gitter channels, forums or mailing lists:
-  whatever can help a student become unstuck.
-
-  This document should **not** link to Exercism-wide (track-agnostic) help resources,
-  as those resources will automatically be included in the HELP.md file.
-
-  The links in this document can overlap with those in docs/LEARNING.md or docs/RESOURCES.md
-
-  When a student downloads an exercise via the CLI, this file's contents are
-  included into the HELP.md file.
-
-  See https://exercism.org/docs/building/tracks/shared-files for more information. -->
+- Make sure you search on [the language overview](https://odin-lang.org/docs/overview) page.
+- Check if your question has already been asked:
+  - on [the Odin forum](https://forum.odin-lang.org),
+  - or [the Odin Discord](https://discord.gg/vafXTdubwr).
+- Ask the Exercism community on [the Exercism Discord](https://exercism.org/r/discord).
+- Experiment on the [Odin playground](https://codapi.org/odin/).

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,15 +1,15 @@
 # Tests
 
-<!-- TODO: write document
+To run the tests from within the exercise directory, run the command:
 
-  This document should contain instructions on how to run the exercise's tests.
+```sh
+odin test .
+```
 
-  The instructions should be short and to the point.
+While you are testing, Odin can "vet" your code: it can look for things like unused imports and variables. Run your tests with:
 
-  The docs/TESTS.md file can contain a more verbose description on how to run tests.
+```sh
+odin test . -vet
+```
 
-  When a student downloads an exercise via the CLI, this file's contents are
-  included into the HELP.md file.
-
-  See https://exercism.org/docs/building/tracks/shared-files for more information.
--->
+For more options, see `odin test -help`.


### PR DESCRIPTION
These files are used to create HELP.md when users download the exercise: https://exercism.org/docs/building/tracks/presentation#h-help-md

This is the last task to check off the "Prepare for launch" step in #1 