### PR TITLE
Add check for missing description tags

### DIFF
--- a/bin/check-exercise.sh
+++ b/bin/check-exercise.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Exit script if any subcommands fail
-# set -eou pipefail
+set -eou pipefail
 
 die () { echo "$*" >&2; exit 1; }
 

--- a/bin/gen-exercise.sh
+++ b/bin/gen-exercise.sh
@@ -36,13 +36,13 @@ get_cache_dir() {
             fi
             ;;
         darwin*)
-            if [[ -e "$HOME/Library/Caches" && -d "$HOME/Library/Caches" ]]; then
+            if [[ -d "$HOME/Library/Caches" ]]; then
                 echo "$HOME/Library/Caches"
                 return
             fi
             ;;
         *)  # lump all the other *nix systems
-            if [[ -e "$HOME/.cache" && -d "$HOME/.cache" ]]; then
+            if [[ -d "$HOME/.cache" ]]; then
                 echo "$HOME/.cache"
                 return
             fi
@@ -226,7 +226,7 @@ if [[ "$extype" == "practice" ]]; then
   for ((i=0; i < canonical_data_length; i++)); do
     case=$( jq -c ".cases.[$i]" <<< "${canonical_data}" )
     english_desc=$(echo "$case" | jq -r '.description // ""')
-    snake_desc=$(echo "$case" | jq -r '.description // ""' | to_snake_case)
+    snake_desc=$(echo "$english_desc" | to_snake_case)
     property=$(echo "$case" | jq -r '.property // ""' | to_snake_case)
     input=$(echo "$case" | jq -c '.input // ""')
     expected=$(echo "$case" | jq -c '.expected // ""')


### PR DESCRIPTION
Update gen-exercise.sh and check-exercise.sh for description tags

Updated gen-exercise.sh to add description tags when generating the test stubs.

Updated check-exercise.sh to fail if a test is missing description tags.