### PR TITLE
Add odinfmt to test-all GHA

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -4,7 +4,7 @@ name: odin/Test
 
 on:
   push:
-    branches: 
+    branches:
       - main
 
 jobs:
@@ -33,6 +33,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           llvm-version: 18
           release: dev-2025-10
+
+      - name: Install odinfmt
+        run: bin/fetch-ols-odinfmt.sh
 
       - name: Verify all exercises
         run: bin/verify-exercises


### PR DESCRIPTION
Replacing run-test.sh with check-exercise.sh in verify-exercise.sh required odinfmt but it was not installed as part of this GHA.