### PR TITLE
Updated tests for exercises using 'slice.equal()' [no important files changed]

### DIFF
--- a/exercises/practice/anagram/anagram_test.odin
+++ b/exercises/practice/anagram/anagram_test.odin
@@ -1,7 +1,17 @@
 package anagram
 
-import "core:slice"
+import "core:fmt"
 import "core:testing"
+
+expect_slices_match :: proc(t: ^testing.T, actual, expected: []$E, loc := #caller_location) {
+	result := fmt.aprintf("%v", actual)
+	exp_str := fmt.aprintf("%v", expected)
+	defer {
+		delete(result)
+		delete(exp_str)
+	}
+	testing.expect_value(t, result, exp_str, loc = loc)
+}
 
 @(test)
 /// description = no matches
@@ -13,7 +23,7 @@ test_no_matches :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -26,7 +36,7 @@ test_detects_two_anagrams :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -39,7 +49,7 @@ test_does_not_detect_anagram_subsets :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -52,7 +62,7 @@ test_detects_anagram :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -65,7 +75,7 @@ test_detects_three_anagrams :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -78,7 +88,7 @@ test_detects_multiple_anagrams_with_different_case :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -91,7 +101,7 @@ test_does_not_detect_non_anagrams_with_identical_checksum :: proc(t: ^testing.T)
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -104,7 +114,7 @@ test_detects_anagrams_case_insensitively :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -117,7 +127,7 @@ test_detects_anagrams_using_case_insensitive_subject :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -130,7 +140,7 @@ test_detects_anagrams_using_case_insensitive_possible_matches :: proc(t: ^testin
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -143,7 +153,7 @@ test_does_not_detect_an_anagram_if_the_original_word_is_repeated :: proc(t: ^tes
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -156,7 +166,7 @@ test_anagrams_must_use_all_letters_exactly_once :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -169,7 +179,7 @@ test_words_are_not_anagrams_of_themselves :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -184,7 +194,7 @@ test_words_are_not_anagrams_of_themselves_even_if_letter_case_is_partially_diffe
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -199,7 +209,7 @@ test_words_are_not_anagrams_of_themselves_even_if_letter_case_is_completely_diff
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -212,7 +222,7 @@ test_words_other_than_themselves_can_be_anagrams :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -225,7 +235,7 @@ test_handles_case_of_greek_letters :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -238,5 +248,5 @@ test_different_characters_may_have_the_same_bytes :: proc(t: ^testing.T) {
 	result := find_anagrams(word, candidates[:])
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }

--- a/exercises/practice/high-scores/high_scores_test.odin
+++ b/exercises/practice/high-scores/high_scores_test.odin
@@ -1,7 +1,17 @@
 package high_scores
 
-import "core:slice"
+import "core:fmt"
 import "core:testing"
+
+expect_slices_match :: proc(t: ^testing.T, actual, expected: []$E, loc := #caller_location) {
+	result := fmt.aprintf("%v", actual)
+	exp_str := fmt.aprintf("%v", expected)
+	defer {
+		delete(result)
+		delete(exp_str)
+	}
+	testing.expect_value(t, result, exp_str, loc = loc)
+}
 
 @(test)
 /// description = List of scores
@@ -14,7 +24,7 @@ test_list_of_scores :: proc(t: ^testing.T) {
 	result := scores(score_board)
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -54,7 +64,7 @@ test_top_3_scores__personal_top_three_from_a_list_of_scores :: proc(t: ^testing.
 	result := personal_top_three(score_board)
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -68,7 +78,7 @@ test_top_3_scores__personal_top_highest_to_lowest :: proc(t: ^testing.T) {
 	result := personal_top_three(score_board)
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -82,7 +92,7 @@ test_top_3_scores__personal_top_when_there_is_a_tie :: proc(t: ^testing.T) {
 	result := personal_top_three(score_board)
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -96,7 +106,7 @@ test_top_3_scores__personal_top_when_there_are_less_than_3 :: proc(t: ^testing.T
 	result := personal_top_three(score_board)
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -110,7 +120,7 @@ test_top_3_scores__personal_top_when_there_is_only_one :: proc(t: ^testing.T) {
 	result := personal_top_three(score_board)
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -141,7 +151,7 @@ test_top_3_scores__scores_after_personal_top_scores :: proc(t: ^testing.T) {
 	result := scores(score_board)
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }
 
 @(test)
@@ -170,5 +180,5 @@ test_top_3_scores__scores_after_personal_best :: proc(t: ^testing.T) {
 	result := scores(score_board)
 	defer delete(result)
 
-	testing.expect(t, slice.equal(result, expected[:]))
+	expect_slices_match(t, result, expected[:])
 }


### PR DESCRIPTION
After PR #161, I went through all the published exercises and checked if any other was using the 'slice.equal()' to compare expected vs result. I found another two and confirmed that the failed test report were confusing ('expected true but got
 false').

[no important files changed]