### PR TITLE
Remove "skeleton file" banner from solution stub

### DIFF
--- a/exercises/practice/high-scores/high_scores.odin
+++ b/exercises/practice/high-scores/high_scores.odin
@@ -1,7 +1,3 @@
-//
-// This is only a SKELETON file for the 'High Scores' exercise. It's been provided as a
-// convenience to get you started writing code faster.
-//
 package high_scores
 
 // Complete the HighScores data structure.


### PR DESCRIPTION
This exercise had the old "This is a SKELETON file ..." banner at the top. We have decided not to use that banner for the track. I checked and it seems to be the only exercise that included it.