### PR TITLE
Update clock.odin to avoid compile error

### DIFF
--- a/exercises/practice/clock/clock.odin
+++ b/exercises/practice/clock/clock.odin
@@ -7,7 +7,7 @@ Clock :: struct {}
 
 create_clock :: proc(hour, minute: int) -> Clock {
 	// Implement this procedure.
-	return
+	return Clock{}
 }
 
 to_string :: proc(clock: Clock) -> string {
@@ -17,12 +17,10 @@ to_string :: proc(clock: Clock) -> string {
 
 add :: proc(clock: ^Clock, minutes: int) {
 	// Implement this procedure.
-	return
 }
 
 subtract :: proc(clock: ^Clock, minutes: int) {
 	// Implement this procedure.
-	return
 }
 
 equals :: proc(clock1, clock2: Clock) -> bool {


### PR DESCRIPTION
The solution stub for clock triggers a couple of compile errors:

1. create_clock doesn't return a proper object
2. add doesn't return a proper object but should not even have a return
2. subtract doesn't return a proper object but should not even have a return

Updated the stub so that it fails the tests without generating compile errors.