### PR TITLE
Fix subtle error in freeing memory in Food Chain

### DIFF
--- a/exercises/practice/food-chain/.meta/example.odin
+++ b/exercises/practice/food-chain/.meta/example.odin
@@ -84,7 +84,6 @@ generate_verse :: proc(builder: ^strings.Builder, i: int) {
 
 recite :: proc(start, end: int) -> string {
 	builder := strings.builder_make()
-	defer strings.builder_destroy(&builder)
 	for i in start - 1 ..< end {
 		generate_verse(&builder, i)
 		strings.write_rune(&builder, '\n')

--- a/exercises/practice/food-chain/food_chain_test.odin
+++ b/exercises/practice/food-chain/food_chain_test.odin
@@ -9,6 +9,7 @@ test_fly :: proc(t: ^testing.T) {
 I don't know why she swallowed the fly. Perhaps she'll die.`
 
 	actual := recite(1, 1)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -20,6 +21,7 @@ She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.`
 
 	actual := recite(2, 2)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -32,6 +34,7 @@ She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.`
 
 	actual := recite(3, 3)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -45,6 +48,7 @@ She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.`
 
 	actual := recite(4, 4)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -59,6 +63,7 @@ She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.`
 
 	actual := recite(5, 5)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -74,6 +79,7 @@ She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.`
 
 	actual := recite(6, 6)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -90,6 +96,7 @@ She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.`
 
 	actual := recite(7, 7)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -99,6 +106,7 @@ test_horse :: proc(t: ^testing.T) {
 She's dead, of course!`
 
 	actual := recite(8, 8)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -119,6 +127,7 @@ She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.`
 
 	actual := recite(1, 3)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }
 @(test)
@@ -176,5 +185,6 @@ I know an old lady who swallowed a horse.
 She's dead, of course!`
 
 	actual := recite(1, 8)
+	defer delete(actual)
 	testing.expect_value(t, actual, expected)
 }


### PR DESCRIPTION
In Odin, when a function returned a dynamically generated string it is up to the caller to reclaim the memory. In the Food Chain exercise, the example solution function `recite()` frees the song string and there is no free in the tests itself. This works because the only thing the test does is call the `recite()` function, checks it is equal to the solution and exit but it is really dealing with deallocated memory at that point and any allocation would corrupt it.

This can be confusing to the student as, if she expects the caller (the test) to free the song string, it will result in a memory leak. Students using the UI will be impervious to the problem but students using the CLI will see it.

I modified the example solution, not to free the song string  and the tests to free it instead. I verified that the solution still work and there is no memory leak.